### PR TITLE
Use pkg-config and Makefile for building adapter

### DIFF
--- a/Adapter/Makefile
+++ b/Adapter/Makefile
@@ -1,0 +1,23 @@
+# Makefile for compiling Elmer modules with libprecice
+
+# Compiler and flags
+FC = elmerf90
+PKG_CONFIG = pkg-config
+LIBPRECICE_FLAGS = $(shell $(PKG_CONFIG) --libs libprecice)
+
+# Source files and targets
+SOURCES = Coupler_Solver.F90 Print_Module.F90 UDF_Boundary.F90
+TARGETS = Coupler_Solver.so Print_Module.so UDF_Boundary.so
+
+# Default target to build all shared libraries
+all: $(TARGETS)
+
+# Rule for compiling .so files
+%.so: %.F90
+	$(FC) -o $@ $< $(LIBPRECICE_FLAGS)
+
+# Clean up object files and shared libraries
+clean:
+	rm -f $(TARGETS)
+
+.PHONY: all clean

--- a/Adapter/build.sh
+++ b/Adapter/build.sh
@@ -1,3 +1,0 @@
-elmerf90 -o Coupler_Solver.so Coupler_Solver.F90 /usr/lib/x86_64-linux-gnu/libprecice.so.3
-elmerf90 -o Print_Module.so Print_Module.F90 /usr/lib/x86_64-linux-gnu/libprecice.so.3
-elmerf90 -o UDF_Boundary.so UDF_Boundary.F90 /usr/lib/x86_64-linux-gnu/libprecice.so.3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The adapter is called during runtime by Elmer. It is developed as a standalone library of Elmer features, so it has to be built before running the simulation. For building, Elmer provides a FORTRAN wrapper to make sure that code compiled by the user is compatible with `ElmerSolver`.
 
-To build the adapter, run the script `Adapter/build.sh`. If Elmer is installed, this script should work out of the box.
+To build the adapter, navigate to the folder `Adapter` and run `make`. If Elmer is installed correctly, this should work out of the box.
 
 ## Use the adapter
 


### PR DESCRIPTION
Avoids having to modify hard-coded paths and uses a more standardized approach.